### PR TITLE
Add default consul host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ yarn add -D serverless-consul-variables
 
 Then inside of your project's `serverless.yml` file add the following to the plugins section. You should change the consul host & port to match your build environment.
 
+**FYI**: It defaults to this values with no need to put them in `serverless.yml`. If you use other values, please, put what you need here.
 ```yaml
 custom:
   serverless-consul-variables:

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ var consulClient;
 export default class ServerlessConsulVariables {
 
   constructor(serverless) {
-    const consulSettings = serverless.service.custom['serverless-consul-variables'] || {};
+    const consulSettings = (serverless.service.custom && serverless.service.custom['serverless-consul-variables']) ? serverless.service.custom['serverless-consul-variables'] : {host: '127.0.0.1', port: 8500};
     consulClient = consul({...consulSettings, promisify: true});
 
     this.serverless = serverless;


### PR DESCRIPTION
No need to put defaults or value in serverless.yaml if using defaults
Defaults to => host: '127.0.0.1', port: 8500