### PR TITLE
Add command hook for consul to get key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,20 +6,45 @@ var consulClient;
 
 export default class ServerlessConsulVariables {
 
-  constructor(serverless) {
+  constructor(serverless, options) {
     const consulSettings = (serverless.service.custom && serverless.service.custom['serverless-consul-variables']) ? serverless.service.custom['serverless-consul-variables'] : {};
     consulClient = consul({...consulSettings, promisify: true});
 
     this.serverless = serverless;
+    this.options = options;
     this.resolvedValues = {};
 
+    this.commands = {
+      consul: {
+        usage: 'Gets value for Key Path from consul KV',
+        lifecycleEvents: [
+          'getValue'
+        ],
+        options: {
+          'get-key': {
+            usage:
+              'Specify the Key Path you want to get '
+              + '(e.g. "--get-key \'my_folder/key\'")',
+            required: true,
+          },
+        },
+      },
+    };
+
+    this.hooks = {
+      'consul:getValue': async () => {
+        const result = await this._getValueFromConsul.call(this, options['get-key']);
+        console.log(result);
+       }
+        
+    }
+
     const delegate = serverless.variables
-      .getValueFromSource.bind(serverless.variables);
+    .getValueFromSource.bind(serverless.variables);
 
     serverless.variables.getValueFromSource = (variableString) => {
       if (variableString.startsWith(`${CONSUL_PREFIX}:`)) {
-        const variable = variableString.split(`${CONSUL_PREFIX}:`)[1];
-        return this._getValueFromConsul(variable);
+        return this._getValueFromConsul(variableString.split(`${CONSUL_PREFIX}:`)[1]);
       }
 
       return delegate(variableString);
@@ -27,6 +52,7 @@ export default class ServerlessConsulVariables {
   }
 
   async _getValueFromConsul(variable) {
+
     if (this.resolvedValues[variable]) {
       return Promise.resolve(this.resolvedValues[variable]);
     }
@@ -39,5 +65,7 @@ export default class ServerlessConsulVariables {
     this.resolvedValues[variable] = data.Value;
     return data.Value;
   }
+
+  
 }
 


### PR DESCRIPTION
This adds sls command to get and test values from consul directly from the cli.

```
# sls consul --get-key                                                                   

  Serverless Error ---------------------------------------

  This command requires the --get-key option. Usage: Specify the Key Path you want to get (e.g. "--get-key 'my_folder/key'")
```